### PR TITLE
Add lto-link-flags.diff to address performance differences

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -26,7 +26,8 @@ RUN export VERSION="$( /usr/bin/dpkg-parsechangelog --show-field Version | cut -
 COPY . .
 
 # CFLAGS appear to be added by dpkg-buildpackage
-RUN export DEB_CFLAGS_STRIP='-O2' DEB_CXXFLAGS_STRIP='-O2' \
+RUN patch -p0 <debian/patches/lto-link-flags.diff \
+    && export DEB_CFLAGS_STRIP='-O2' DEB_CXXFLAGS_STRIP='-O2' \
     && dpkg-buildflags \
     && DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck" dpkg-buildpackage -B
 

--- a/build/debian/patches/lto-link-flags.diff
+++ b/build/debian/patches/lto-link-flags.diff
@@ -1,0 +1,24 @@
+Index: Makefile.pre.in
+===================================================================
+--- Makefile.pre.in
++++ Makefile.pre.in
+@@ -122,8 +122,8 @@ LIBP=		$(LIBDIR)/python$(VERSION)
+ 
+ # Symbols used for using shared libraries
+ SO=		@SO@
+-LDSHARED=	@LDSHARED@ $(LDFLAGS)
+-BLDSHARED=	@BLDSHARED@ $(LDFLAGS)
++LDSHARED=	@LDSHARED@ $(PY_LDFLAGS)
++BLDSHARED=	@BLDSHARED@ $(PY_LDFLAGS) $(PY_CFLAGS)
+ LDCXXSHARED=	@LDCXXSHARED@
+ DESTSHARED=	$(BINLIBDEST)/lib-dynload
+ 
+@@ -507,7 +507,7 @@ coverage-report:
+ 
+ # Build the interpreter
+ $(BUILDPYTHON):	Modules/python.o $(LIBRARY) $(LDLIBRARY)
+-		$(LINKCC) $(LDFLAGS) $(LINKFORSHARED) -o $@ \
++		$(LINKCC) $(PY_LDFLAGS) $(PY_CFLAGS) $(LINKFORSHARED) -o $@ \
+ 			Modules/python.o \
+ 			$(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
+ 

--- a/build/debian/patches/series
+++ b/build/debian/patches/series
@@ -1,0 +1,1 @@
+lto-link-flags.diff


### PR DESCRIPTION
It looks like a key performance difference is due to the flags passed during compilation; this patch is applied by Debian and so the Ubuntu packages also benefit.

Applying just this patch gets the test execution time down to the expected ~5s. There may be smaller optimisations in the other Debian patches but they didn't make a noticeable difference for this specific test case - this patch is the key change.

However, switching to a newer Ubuntu version (with newer GCC) might provide much more improvement. During my testing I compiled Python 2.7 without the `--enable-optimizations` configure flag (or any other configure flags, for that matter) and found 64-bit 16.04 (GCC 5.4.1) runs the same test code in 1.5s, though this may simply be the later GCC version optimising out the loop.